### PR TITLE
Update package name and legacy terms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# w3c-ccg/status-list-2021-test-suite ChangeLog
+# w3c-ccg/vc-bitstring-status-list-test-suite ChangeLog
 
 ## 1.1.0 - 2023-12-14
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bitstring Status List Interoperability Test Suite
+# VC Bitstring Status List Interoperability Test Suite
 
 ## Table of Contents
 
@@ -11,7 +11,7 @@
 ## Background
 
 Provides interoperability tests for issuers and verifiers that support
-[VC Bitstring Status List](https://w3c-ccg.github.io/vc-bitstring-status-list/).
+[VC Bitstring Status List](https://w3c.github.io/vc-bitstring-status-list/).
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Status List 2021 Interoperability Test Suite
+# Bitstring Status List Interoperability Test Suite
 
 ## Table of Contents
 
@@ -10,7 +10,8 @@
 
 ## Background
 
-Provides interoperability tests for issuers and verifiers that support [VC StatusList2021](https://w3c-ccg.github.io/vc-status-list-2021/).
+Provides interoperability tests for issuers and verifiers that support
+[VC Bitstring Status List](https://w3c-ccg.github.io/vc-bitstring-status-list/).
 
 ## Install
 
@@ -35,8 +36,9 @@ npm run generate-vcs
 ## Implementation
 
 To add your implementation to this test suite see the
-`w3c-ccg/vc-test-suite-implementations` [README](https://github.com/w3c-ccg/vc-test-suite-implementations/blob/main/README.md). Add the tags `StatusList2021` along with `Revocation` or
-`Suspension` to run your issuer and verifier against this test suite.
+`w3c-ccg/vc-test-suite-implementations` [README](https://github.com/w3c-ccg/vc-test-suite-implementations/blob/main/README.md). Add the tags
+`BitstringStatusList` along with `Revocation` or `Suspension` to run your
+issuer and verifier against this test suite.
 
 Note: To run the tests, some implementations require client secrets that can be
 passed as env variables to the test script. To see which ones require client

--- a/abstract.hbs
+++ b/abstract.hbs
@@ -1,7 +1,7 @@
 <section id='abstract'>
  <p>
   The purpose of this test suite is to demonstrate a path to interoperability
-  for <a href="https://w3c-ccg.github.io/vc-status-list-2021/">StatusList2021
-  </a>.
+  for <a href="https://w3c.github.io/vc-bitstring-status-list/">Bitstring Status
+  List</a>.
   </p>
 </section>

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "klona": "^2.0.6",
     "mocha": "^10.2.0",
     "uuid": "^9.0.0",
-    "vc-test-suite-implementations": "github:w3c-ccg/vc-test-suite-implementations"
+    "vc-test-suite-implementations": "github:w3c-ccg/vc-test-suite-implementations#update-status-list-tag"
   },
   "devDependencies": {
     "eslint": "^8.54.0",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "status-list-2021-test-suite",
+  "name": "vc-bitstring-status-list-test-suite",
   "version": "0.1.0",
-  "description": "Interoperability Tests for StatusList2021",
+  "description": "Interoperability Tests for Bitstring Status List",
   "main": "/tests",
   "type": "module",
   "scripts": {
-    "test": "mocha tests --reporter @digitalbazaar/mocha-w3c-interop-reporter --reporter-options  abstract=\"$PWD/abstract.hbs\",reportDir=\"$PWD/reports\",respec=\"$PWD/respecConfig.json\",suiteLog='./suite.log',templateData=\"$PWD/reports/index.json\",title=\"Status List 2021 Interoperability Report 1.0\" --timeout 15000 --preserve-symlinks",
+    "test": "mocha tests --reporter @digitalbazaar/mocha-w3c-interop-reporter --reporter-options  abstract=\"$PWD/abstract.hbs\",reportDir=\"$PWD/reports\",respec=\"$PWD/respecConfig.json\",suiteLog='./suite.log',templateData=\"$PWD/reports/index.json\",title=\"VC Bitstring List Interoperability Report 1.0\" --timeout 15000 --preserve-symlinks",
     "lint": "eslint ."
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/w3c-ccg/status-list-2021-test-suite.git"
+    "url": "git+https://github.com/w3c-ccg/bitstring-status-list-test-suite.git"
   },
   "keywords": [
     "Test",
@@ -49,7 +49,7 @@
     "eslint-plugin-unicorn": "^49.0.0"
   },
   "bugs": {
-    "url": "https://github.com/w3c-ccg/status-list-2021-test-suite/issues"
+    "url": "https://github.com/w3c-ccg/bitstring-status-list-test-suite/issues"
   },
-  "homepage": "https://github.com/w3c-ccg/status-list-2021-test-suite#readme"
+  "homepage": "https://github.com/w3c-ccg/bitstring-status-list-test-suite#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vc-bitstring-status-list-test-suite",
   "version": "0.1.0",
-  "description": "Interoperability Tests for Bitstring Status List",
+  "description": "Interoperability Tests for VC Bitstring Status List",
   "main": "/tests",
   "type": "module",
   "scripts": {
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/w3c-ccg/bitstring-status-list-test-suite.git"
+    "url": "https://github.com/w3c-ccg/vc-bitstring-status-list-test-suite"
   },
   "keywords": [
     "Test",
@@ -49,7 +49,7 @@
     "eslint-plugin-unicorn": "^49.0.0"
   },
   "bugs": {
-    "url": "https://github.com/w3c-ccg/bitstring-status-list-test-suite/issues"
+    "url": "https://github.com/w3c-ccg/vc-bitstring-status-list-test-suite/issues"
   },
-  "homepage": "https://github.com/w3c-ccg/bitstring-status-list-test-suite#readme"
+  "homepage": "https://github.com/w3c-ccg/vc-bitstring-status-list-test-suite#readme"
 }

--- a/respecConfig.json
+++ b/respecConfig.json
@@ -1,9 +1,9 @@
 {
   "specStatus": "unofficial",
-  "shortName": "status-list-2021-test-suite",
+  "shortName": "vc-bitstring-status-list-test-suite",
   "subtitle": "Test Interoperability Report for Verifiable Credentials status",
-  "github": "https://github.com/w3c-ccg/status-list-2021-test-suite",
-  "edDraftURI": "https://w3c-ccg.github.io/status-list-2021-test-suite",
+  "github": "https://github.com/w3c-ccg/vc-bitstring-status-list-test-suite",
+  "edDraftURI": "https://w3c-ccg.github.io/vc-bitstring-status-list-test-suite",
   "doJsonLd": true,
   "includePermalinks": false,
   "editors": [

--- a/tests/10-issue.js
+++ b/tests/10-issue.js
@@ -9,12 +9,12 @@ import {filterByTag} from 'vc-test-suite-implementations';
 
 const should = chai.should();
 
-// only use implementations with `StatusList2021` issuers.
+// only use implementations with `BitstringStatusList` issuers.
 const {match} = filterByTag({
   property: 'issuers',
-  tags: ['StatusList2021']
+  tags: ['BitstringStatusList']
 });
-describe('StatusList2021 Credentials (Issue "statusPurpose: revocation")',
+describe('BitstringStatusList Credentials (Issue "statusPurpose: revocation")',
   function() {
     this.matrix = true;
     this.report = true;
@@ -33,7 +33,7 @@ describe('StatusList2021 Credentials (Issue "statusPurpose: revocation")',
           issuerResponse = result;
           issuedVc = data;
         });
-        it('MUST issue a VC with SL 2021 "credentialStatus" and ' +
+        it('MUST issue a VC with BitstringStatusList "credentialStatus" and ' +
           '"revocation" status purpose', async function() {
           this.test.cell = {columnId: issuerName, rowId: this.test.title};
           should.exist(issuerResponse);
@@ -60,7 +60,7 @@ describe('StatusList2021 Credentials (Issue "statusPurpose: revocation")',
             // decoded size should be 16kb. For more info see
             // `credentialSubject.encoded` in
             // eslint-disable-next-line max-len
-            // https://w3c-ccg.github.io/vc-status-list-2021/#statuslist2021credential
+            // https://w3c-ccg.github.io/vc-bitstring-status-list/#BitstringStatuslistCredential
             const decodedSize = (decoded.length / 8) / 1024;
             decodedSize.should.equal(16);
           });
@@ -68,7 +68,7 @@ describe('StatusList2021 Credentials (Issue "statusPurpose: revocation")',
     }
   });
 
-describe('StatusList2021 Credentials (Issue "statusPurpose: suspension")',
+describe('BitstringStatusList Credentials (Issue "statusPurpose: suspension")',
   function() {
     this.matrix = true;
     this.report = true;
@@ -87,7 +87,7 @@ describe('StatusList2021 Credentials (Issue "statusPurpose: suspension")',
           issuerResponse = result;
           issuedVc = data;
         });
-        it('MUST issue a VC with SL 2021 "credentialStatus" and ' +
+        it('MUST issue a VC with BitstringStatusList "credentialStatus" and ' +
           '"suspension" status purpose', async function() {
           this.test.cell = {columnId: issuerName, rowId: this.test.title};
           should.exist(issuerResponse);

--- a/tests/20-verify.js
+++ b/tests/20-verify.js
@@ -9,13 +9,13 @@ import {filterByTag, filterImplementations} from
 import {shouldFailVerification, shouldPassVerification} from './assertions.js';
 import {klona} from 'klona';
 
-// only use implementations with `StatusList2021` verifiers.
+// only use implementations with `BitstringStatusList` verifiers.
 const {match} = filterByTag({
   property: 'verifiers',
-  tags: ['StatusList2021']
+  tags: ['BitstringStatusList']
 });
 
-describe('StatusList2021 Credentials (Verify)', function() {
+describe('BitstringStatusList Credentials (Verify)', function() {
   this.matrix = true;
   this.report = true;
   this.implemented = [...match.keys()];
@@ -24,7 +24,7 @@ describe('StatusList2021 Credentials (Verify)', function() {
   for(const [verifierName, {verifiers}] of match) {
     describe(verifierName, function() {
       const verifier = verifiers.find(verifier =>
-        verifier.tags.has('StatusList2021'));
+        verifier.tags.has('BitstringStatusList'));
       let validVcForRevocation;
       let validVcForSuspension;
       let setRevocationStatusList;
@@ -54,16 +54,16 @@ describe('StatusList2021 Credentials (Verify)', function() {
         const {data: data2} = await issueVc({issuer: issuer2});
         validVcForSuspension = data2;
       });
-      it('MUST verify a valid "StatusList2021Credential" with "revocation" ' +
-        'status purpose', async function() {
+      it('MUST verify a valid "BitstringStatusListCredential" with ' +
+        '"revocation" status purpose', async function() {
         this.test.cell = {columnId: verifierName, rowId: this.test.title};
         const {result, error, statusCode} = await verifier.post({
           json: createRequestBody({vc: validVcForRevocation})
         });
         shouldPassVerification({result, error, statusCode});
       });
-      it('MUST verify a valid "StatusList2021Credential" with "suspension"' +
-        'status purpose', async function() {
+      it('MUST verify a valid "BitstringStatusListCredential" with ' +
+        '"suspension" status purpose', async function() {
         this.test.cell = {columnId: verifierName, rowId: this.test.title};
         const {result, error, statusCode} = await verifier.post({
           json: createRequestBody({vc: validVcForSuspension})

--- a/tests/30-interop.js
+++ b/tests/30-interop.js
@@ -8,75 +8,75 @@ import {shouldPassVerification} from './assertions.js';
 
 const should = chai.should();
 
-// only use implementations with `StatusList2021` tags.
+// only use implementations with `BitstringStatusList` tags.
 const {match: issuerMatches} = endpoints.filterByTag({
   property: 'issuers',
-  tags: ['StatusList2021']
+  tags: ['BitstringStatusList']
 });
 
 const {match: verifierMatches} = endpoints.filterByTag({
   property: 'verifiers',
-  tags: ['StatusList2021']
+  tags: ['BitstringStatusList']
 });
 
-describe('StatusList2021 Credentials (Interop "statusPurpose: revocation")',
-  function() {
-    // this will tell the report
-    // to make an interop matrix with this suite
-    this.matrix = true;
-    this.report = true;
-    this.implemented = [...verifierMatches.keys()];
-    this.rowLabel = 'Issuer';
-    this.columnLabel = 'Verifier';
-    for(const [issuerName, {endpoints}] of issuerMatches) {
-      let issuedVc;
-      before(async function() {
-        const [issuer] = endpoints.filter(
-          endpoint => endpoint.settings.tags.includes('Revocation'));
-        issuedVc = issueVc({issuer});
+describe('BitstringStatusList Credentials (Interop "statusPurpose: ' +
+  'revocation")', function() {
+  // this will tell the report
+  // to make an interop matrix with this suite
+  this.matrix = true;
+  this.report = true;
+  this.implemented = [...verifierMatches.keys()];
+  this.rowLabel = 'Issuer';
+  this.columnLabel = 'Verifier';
+  for(const [issuerName, {endpoints}] of issuerMatches) {
+    let issuedVc;
+    before(async function() {
+      const [issuer] = endpoints.filter(
+        endpoint => endpoint.settings.tags.includes('Revocation'));
+      issuedVc = issueVc({issuer});
+    });
+    for(const [verifierName, {endpoints}] of verifierMatches) {
+      const [verifier] = endpoints;
+      it(`${verifierName} should verify ${issuerName}`, async function() {
+        this.test.cell = {rowId: issuerName, columnId: verifierName};
+        const {data: vc, error: err} = await issuedVc;
+        should.not.exist(err);
+        should.exist(vc);
+        const body = createRequestBody({vc});
+        const {result, error, statusCode} = await verifier.post({json: body});
+        shouldPassVerification({result, error, statusCode});
       });
-      for(const [verifierName, {endpoints}] of verifierMatches) {
-        const [verifier] = endpoints;
-        it(`${verifierName} should verify ${issuerName}`, async function() {
-          this.test.cell = {rowId: issuerName, columnId: verifierName};
-          const {data: vc, error: err} = await issuedVc;
-          should.not.exist(err);
-          should.exist(vc);
-          const body = createRequestBody({vc});
-          const {result, error, statusCode} = await verifier.post({json: body});
-          shouldPassVerification({result, error, statusCode});
-        });
-      }
     }
-  });
+  }
+});
 
-describe('StatusList2021 Credentials (Interop "statusPurpose: suspension")',
-  function() {
-    // this will tell the report
-    // to make an interop matrix with this suite
-    this.matrix = true;
-    this.report = true;
-    this.implemented = [...verifierMatches.keys()];
-    this.rowLabel = 'Issuer';
-    this.columnLabel = 'Verifier';
-    for(const [issuerName, {endpoints}] of issuerMatches) {
-      let issuedVc;
-      before(async function() {
-        const [issuer] = endpoints.filter(
-          endpoint => endpoint.settings.tags.includes('Suspension'));
-        issuedVc = issueVc({issuer});
+describe('BitstringStatusList Credentials (Interop "statusPurpose: ' +
+  'suspension")', function() {
+  // this will tell the report
+  // to make an interop matrix with this suite
+  this.matrix = true;
+  this.report = true;
+  this.implemented = [...verifierMatches.keys()];
+  this.rowLabel = 'Issuer';
+  this.columnLabel = 'Verifier';
+  for(const [issuerName, {endpoints}] of issuerMatches) {
+    let issuedVc;
+    before(async function() {
+      const [issuer] = endpoints.filter(
+        endpoint => endpoint.settings.tags.includes('Suspension'));
+      issuedVc = issueVc({issuer});
+    });
+    for(const [verifierName, {endpoints}] of verifierMatches) {
+      const [verifier] = endpoints;
+      it(`${verifierName} should verify ${issuerName}`, async function() {
+        this.test.cell = {rowId: issuerName, columnId: verifierName};
+        const {data: vc, error: err} = await issuedVc;
+        should.not.exist(err);
+        should.exist(vc);
+        const body = createRequestBody({vc});
+        const {result, error, statusCode} = await verifier.post({json: body});
+        shouldPassVerification({result, error, statusCode});
       });
-      for(const [verifierName, {endpoints}] of verifierMatches) {
-        const [verifier] = endpoints;
-        it(`${verifierName} should verify ${issuerName}`, async function() {
-          this.test.cell = {rowId: issuerName, columnId: verifierName};
-          const {data: vc, error: err} = await issuedVc;
-          should.not.exist(err);
-          should.exist(vc);
-          const body = createRequestBody({vc});
-          const {result, error, statusCode} = await verifier.post({json: body});
-          shouldPassVerification({result, error, statusCode});
-        });
-      }
     }
-  });
+  }
+});

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -22,7 +22,7 @@ export const testCredential = ({credential}) => {
   credential.should.have.property('@context');
   credential['@context'].should.include.members([
     'https://www.w3.org/2018/credentials/v1',
-    'https://w3id.org/vc/status-list/2021/v1',
+    'https://w3id.org/vc/bitstring-status-list/v1',
     'https://w3id.org/security/data-integrity/v2'
   ]);
   credential.should.have.property('type');
@@ -58,7 +58,7 @@ export const testCredential = ({credential}) => {
   ]);
   credential.credentialStatus.statusPurpose.should.be.oneOf(
     ['revocation', 'suspension']);
-  credential.credentialStatus.type.should.equal('StatusList2021Entry');
+  credential.credentialStatus.type.should.equal('BitstringStatusListEntry');
 };
 
 export const testSlCredential = ({slCredential}) => {
@@ -67,13 +67,13 @@ export const testSlCredential = ({slCredential}) => {
   slCredential.should.have.property('@context');
   slCredential['@context'].should.include.members([
     'https://www.w3.org/2018/credentials/v1',
-    'https://w3id.org/vc/status-list/2021/v1',
+    'https://w3id.org/vc/bitstring-status-list/v1',
     'https://w3id.org/security/data-integrity/v2'
   ]);
   slCredential.should.have.property('type');
   slCredential.type.should.be.an('array');
   slCredential.type.should.include.members(
-    ['VerifiableCredential', 'StatusList2021Credential']);
+    ['VerifiableCredential', 'BitstringStatusListCredential']);
   slCredential.should.have.property('id');
   slCredential.id.should.be.a('string');
   slCredential.should.have.property('credentialSubject');
@@ -83,7 +83,7 @@ export const testSlCredential = ({slCredential}) => {
   credentialSubject.id.should.be.a('string');
   credentialSubject.encodedList.should.be.a('string');
   credentialSubject.type.should.be.a('string');
-  credentialSubject.type.should.eql('StatusList2021');
+  credentialSubject.type.should.eql('BitstringStatusList');
   slCredential.should.have.property('issuer');
   const issuerType = typeof(slCredential.issuer);
   issuerType.should.be.oneOf(['string', 'object']);

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -22,7 +22,7 @@ export const testCredential = ({credential}) => {
   credential.should.have.property('@context');
   credential['@context'].should.include.members([
     'https://www.w3.org/2018/credentials/v1',
-    'https://w3id.org/vc/bitstring-status-list/v1',
+    'https://w3id.org/vc/status-list/2021/v1',
     'https://w3id.org/security/data-integrity/v2'
   ]);
   credential.should.have.property('type');
@@ -67,7 +67,7 @@ export const testSlCredential = ({slCredential}) => {
   slCredential.should.have.property('@context');
   slCredential['@context'].should.include.members([
     'https://www.w3.org/2018/credentials/v1',
-    'https://w3id.org/vc/bitstring-status-list/v1',
+    'https://w3id.org/vc/status-list/2021/v1',
     'https://w3id.org/security/data-integrity/v2'
   ]);
   slCredential.should.have.property('type');

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -76,7 +76,7 @@ export const createRequestBody = ({vc, setStatus = false, statusPurpose}) => {
     body = {
       credentialId: vc.id,
       credentialStatus: {
-        type: 'StatusList2021Entry',
+        type: 'BitstringStatusListEntry',
         statusPurpose
       }
     };


### PR DESCRIPTION
- Updated package name - Changed from `status-list-2021-test-suite` to `vc-bitstring-status-list-test-suite`
- Updated legacy terms:
  - Changed `StatusList2021` to `BitstringStatusList`,
  - Changed `StatusList2021Credential` to `BitstringStatusListCredential`.
  - Changed `StatusList2021Entry` to `BitstringStatusListEntry`.
 - Changed tag to run the test from `StatusList2021` to `BitstringStatusList`. 

NOTE: This has not been tested. We do not want to merge this until we have implementations that uses the latest contexts. Leaving the PR as a draft for now. Also tag in vc-test-suite-implementations in w3c-ccg org will have to be updated when this PR is merged. There is a [draft PR]( https://github.com/w3c-ccg/vc-test-suite-implementations/pull/99) for that there.)

TODO:

- [ ] Test cases will have to updated to match the normative statements in the spec.
- [ ] Credential context URLs and Bitstring Status List will have to be updated to use latest ones.  (VC data model 2.0 and the bitstring status list context with the updated terms)