### PR TITLE
fix: mutate on deep copy of validVc

### DIFF
--- a/tests/20-algorithms.js
+++ b/tests/20-algorithms.js
@@ -34,7 +34,9 @@ describe('Algorithm', function() {
         'statements, a MALFORMED_VALUE_ERROR MUST be raised.',
       async function() {
         this.test.link = '';
-        const credential = require('./validVc.json');
+        const credential = JSON.parse(
+          JSON.stringify(require('./validVc.json'))
+        );
 
         // Create a negative fixture
         credential.statusEntry = {


### PR DESCRIPTION
By mutating `require` variable of credential, other variable reading require starting viewing the mutated value. Example, once https://github.com/w3c/vc-bitstring-status-list-test-suite/blob/7d4f1d2c393fc049312a5b822f2149f0d9c93ae2/tests/20-algorithms.js#L40 is executed, other test running after it, reads `./validVc.json` as 

```js
{
  '@context': [ 'https://www.w3.org/ns/credentials/v2' ],
  type: [ 'VerifiableCredential' ],
  credentialSubject: { id: 'did:key:z6MkhTNL7i2etLerDK8Acz5t528giE5KA4p75T6ka1E1D74r' },
  statusEntry: {
    type: 'BitstringStatusListEntry',
    statusListIndex: true,
    statusListCredential: 'https://example.com'
  }
}
```  
at https://github.com/w3c/vc-bitstring-status-list-test-suite/blob/7d4f1d2c393fc049312a5b822f2149f0d9c93ae2/tests/helpers.js#L67
