### PR TITLE
Change title of interop for BitstringStatusList so it is ignored.

### DIFF
--- a/tests/30-interop.js
+++ b/tests/30-interop.js
@@ -20,7 +20,7 @@ function setupMatrix() {
   this.columnLabel = 'Verifier';
 }
 
-describe('Interop', function() {
+describe('BitstringStatusList (interop)', function() {
   setupMatrix.call(this, match);
   for(const [issuerName, implementation] of match) {
     const endpoints = new TestEndpoints({implementation, tag});


### PR DESCRIPTION
The mocha reporter ignores At Risk statements from matrices with `(interop)` in their title:

https://github.com/digitalbazaar/mocha-w3c-interop-reporter/blob/9e748dcafe028ac75c2c4bb9e5e4e7f41a094c6a/lib/extensions.js#L34

So this PR makes the interop tests for BitStringStatusList conform to that standard.
