### PR TITLE
fix: issuer object check

### DIFF
--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -34,8 +34,7 @@ export const testCredential = ({credential}) => {
   const issuerType = typeof (credential.issuer);
   issuerType.should.be.oneOf(['string', 'object']);
   if(issuerType === 'object') {
-    should.exist(credential.issuer.id)
-      .and.to.be.an('object');
+    credential.issuer.should.have.property('id').that.is.a('string');
   }
 };
 


### PR DESCRIPTION
The previous version of the code failed with:

```node
Any expression of the data model in this section MUST be expressed in a conforming verifiable credential as defined in [VC-DATA-MODEL-2.0].
      TypeError: Cannot read properties of undefined (reading 'and')
```

According to the official spec https://w3c.github.io/vc-data-model/#example-expanded-use-of-the-issuer-property

```json 
"issuer": {
    "id": "did:example:76e12ec712ebc6f1c221ebfeb1f",
    "name": "Example University"
}
````
 should be validated as a valid issuer object.

![image](https://github.com/user-attachments/assets/38f8dceb-20ee-44e3-a199-371bab9a3e0f)

