### PR TITLE
Hide At Risk section to accommodate claim.

### DIFF
--- a/abstract.hbs
+++ b/abstract.hbs
@@ -10,4 +10,15 @@
     a successful implemention of every feature, including the ability to
     host multiple statuses in a single list.
   </p>
+
+  <style>
+    /* The "At Risk" section is currently hidden due to the above claim */
+    .tocxref[href="#At Risk"],
+    section#At\ Risk {
+      display: none;
+    }
+    .at-risk {
+      outline: none;
+    }
+  </style>
 </section>

--- a/abstract.hbs
+++ b/abstract.hbs
@@ -12,7 +12,9 @@
   </p>
 
   <style>
-    /* The "At Risk" section is currently hidden due to the above claim */
+    /* The "At Risk" section is currently hidden due to
+       Tradeverifyd's claim of support for every feature
+    */
     .tocxref[href="#At Risk"],
     section#At\ Risk {
       display: none;


### PR DESCRIPTION
The claim made in the abstract suggests that all features are
implemented, consequently, even features shown with a single implementer
are no longer at risk.

However, this change should be reverted once data can be provided.
